### PR TITLE
Use TopoJSON for poverty data

### DIFF
--- a/source/javascripts/layerListModel.coffee
+++ b/source/javascripts/layerListModel.coffee
@@ -54,8 +54,8 @@ window.dashboard.service('layerListModel', ['$rootScope', 'styleHelper', ($rootS
         active: true,
         displayed: true,
         source: {
-          type: 'GeoJSON',
-          url: 'data/poverty.geojson'
+          type: 'TopoJSON',
+          url: 'data/poverty.json'
         }
         style: styleHelper.povertyAvgStyle
         selectedStyle: "povertyAvgStyle"


### PR DESCRIPTION
## What does this PR do?

It replaces the Poverty Data with a TopoJSON version. 
TopoJSON is simplified GeoJSON and is much smaller and faster.
The TopoJSON file is only 5MB big in comparison to 74MB for the GeoJSON file.

It does improve the render time from ~10 seconds to 2-3 seconds.
