### PR TITLE
Hide angular element while angular is loading

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -6,7 +6,7 @@ title: Recovery Dashboard
   %openlayers(class="dashboard-map" custom-layers="true" ol-defaults="defaults" ol-center="nepal")
     %ol-layer(ol-layer-properties="layer" ng-repeat="layer in layers|filter:{active:true}")
 
-  #popup
+  #popup.ng-cloak
     .poverty(ng-show="name=='poverty'")
       %h4 {{properties.OBJECTID}}
       .content
@@ -53,7 +53,7 @@ title: Recovery Dashboard
       %h4 {{properties.NAME}}
       .content
         %p OSM_ID: {{properties.OSM_ID}}
-  #layers
+  #layers.ng-cloak
     .groups(ng-repeat="group in layerGroups")
       %h4 {{group.name}}
       .layer(ng-repeat="layer in group.layers" ng-mouseover="layer.visible=true;" ng-mouseout="toggleVisibility()" ng-model="layer")

--- a/source/partials/_sidebar.html.haml
+++ b/source/partials/_sidebar.html.haml
@@ -1,4 +1,4 @@
-.sidebar(ng-controller="SidebarCtrl" ng-class="{active: show}")
+.sidebar.ng-cloak(ng-controller="SidebarCtrl" ng-class="{active: show}")
   .pull(ng-click="toggleSidebar()" ng-hide="show")
   #sidebar(ng-show="show")
     .close(ng-click="toggleSidebar()")

--- a/source/stylesheets/_main.sass
+++ b/source/stylesheets/_main.sass
@@ -1,3 +1,6 @@
+[ng\:cloak], [ng-cloak], .ng-cloak
+  display: none !important
+
 #recovery-dashboard
   position: absolute
   width: 100%


### PR DESCRIPTION
## What does this PR do?

Adds ng-cloack class to hide elements that need angular to look good, hide them until angular is
ready to deal with them
### Related Issues:

fixes #41
