### PR TITLE
Add first nasa layer from labs geonode

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "underscore":"",
     "jquery":"",
-    "angular-leaflet-directive":"",
     "angular-openlayers-directive":"",
     "d3":"",
     "colorbrewer":""

--- a/source/javascripts/components/layerListModel.coffee
+++ b/source/javascripts/components/layerListModel.coffee
@@ -261,9 +261,12 @@ angular.module('dashboard').service('layerListModel', ['$rootScope', 'styleHelpe
     displayed: false,
     visible: false,
     source: {
-      type: 'TileVector',
-      format: new ol.format.GeoJSON()
-      url: 'http://52.7.33.4/nasa/{z}/{x}/{y}.geojson'
+      type: 'ImageWMS',
+      url: 'http://45.55.174.20/geoserver/wms'
+      params: {
+        layers: "hazard:aria_dpm_alos2_f550_v05u_climmax07454_t1h1b0u0_dpmraw"
+        query_layers: "hazard:aria_dpm_alos2_f550_v05u_climmax07454_t1h1b0u0_dpmraw"
+      }
     }
     metadata: {
       name: "Damages from NASA"


### PR DESCRIPTION
## What does this PR do?

Adds the "Damage Proxy Map (NASA JPL)" from the Labs geonode
### Screenshot

![bildschirmfoto 2015-05-28 um 16 24 11](https://cloud.githubusercontent.com/assets/688980/7862408/0a872f7a-0556-11e5-9577-9c2021beb497.png)
### Related Issues
#28
#57
